### PR TITLE
Small improvements to fairness of tests

### DIFF
--- a/node_io_speed.js
+++ b/node_io_speed.js
@@ -1,6 +1,8 @@
 var sharp = require('sharp')
 var async = require('async')
 
+sharp.simd(true);
+
 var SIZES = {
   large: [800, 800],
   medium: [500, 500],

--- a/node_io_speed_streams.js
+++ b/node_io_speed_streams.js
@@ -2,6 +2,8 @@ var sharp = require('sharp')
 var async = require('async')
 var fs = require('fs')
 
+sharp.simd(true);
+
 var SIZES = {
   large: [800, 800],
   medium: [500, 500],
@@ -13,7 +15,7 @@ var performUpload = function(size, next){
   var resizer = function(){
     var client = sharp()
     return client.resize.
-      apply(client, SIZES[size]).max()
+      apply(client, SIZES[size])
   }
 
   var stream = image.pipe(resizer(size)).pipe(fs.createWriteStream(name))

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   "dependencies": {
     "async": "^1.4.2",
     "dotenv": "^1.2.0",
-    "sharp": "^0.11.3"
+    "sharp": "^0.18.2"
   }
 }


### PR DESCRIPTION
Hello, thanks for creating this benchmark. This PR contains a few small changes to ensure the tests are as close as possible to each other.

To start with, here are the times I see locally on an Intel i3-4170 CPU running Ubuntu 16.04 and using libvips 8.6.0 (master/HEAD) when running the original, unmodified tests:

```
ruby ruby_io_speed.rb
Took: 324ms
node node_io_speed.js
Took: 208.100ms
node node_io_speed_streams.js
Took: 373.145ms
```

The first thing I noticed was that the Node Streams version specifies the `max` option where the other tests do not. Correcting this slows it by ~10%:

```
ruby ruby_io_speed.rb
Took: 314ms
node node_io_speed.js
Took: 207.065ms
node node_io_speed_streams.js
Took: 412.869ms
```

Secondly I updated to the latest version of sharp, given the older version specified here had poorer stream performance and slightly poorer image quality. This brings the two Node tests much closer to each other.

```
ruby ruby_io_speed.rb
Took: 324ms
node node_io_speed.js
Took: 246.919ms
node node_io_speed_streams.js
Took: 262.504ms
```

Finally, SIMD is enabled for the ruby bindings by default but with the latest sharp is not, due mainly to a few reported crashes from liborc when under load. Enabling this produces:

```
ruby ruby_io_speed.rb
Took: 322ms
node node_io_speed.js
Took: 204.619ms
node node_io_speed_streams.js
Took: 224.569ms
```

Switching from the large "cakes" image to the smaller "bridge" image generates a lot more variance in the run times:

```
ruby ruby_io_speed.rb
Took: 90ms
node node_io_speed.js
Took: 112.317ms
node node_io_speed_streams.js
Took: 133.813ms
```

In summary, the winner here is libvips regardless of language used to access it :)