### PR TITLE
Fix image resizing to maintain ratio.

### DIFF
--- a/node_io_speed.js
+++ b/node_io_speed.js
@@ -12,7 +12,7 @@ var SIZES = {
 var performUpload = function(size, next){
   var name = size + ".jpg"
   sharp('cakes.jpg')
-    .resize(SIZES[size][0], SIZES[size][1])
+    .resize(SIZES[size][0])
     .toFile(name, next);
 }
 

--- a/node_io_speed_streams.js
+++ b/node_io_speed_streams.js
@@ -15,7 +15,7 @@ var performUpload = function(size, next){
   var resizer = function(){
     var client = sharp()
     return client.resize.
-      apply(client, SIZES[size])
+      apply(client, [SIZES[size][0]])
   }
 
   var stream = image.pipe(resizer(size)).pipe(fs.createWriteStream(name))


### PR DESCRIPTION
The image resizing for Node was not preserving the aspect ratio. This PR fixes it so both ruby and node conversions produce the same resized images.